### PR TITLE
Add validity check of the returned partition value

### DIFF
--- a/mlxbf-bootctl.c
+++ b/mlxbf-bootctl.c
@@ -154,7 +154,7 @@ int get_boot_partition(void)
   int part = ((ext_csd[EXT_CSD_PART_CONFIG] >> 3) & 0x7) - 1;
 
   /* Set part to 0 by default if it is -1 (boot disabled). */
-  if (part < 0)
+  if (part < 0 || part > 1)
     part = 0;
 
   return part;


### PR DESCRIPTION
This commit adds validity check of the returned partition and
set it to default value if needed. It fixes potential issues
on new card where the value is not initialized properly.