### PR TITLE
Fix compiling issue for compiler without CRC extension

### DIFF
--- a/mlxbf-bootctl.spec
+++ b/mlxbf-bootctl.spec
@@ -1,6 +1,6 @@
 Name: mlxbf-bootctl
 Version: 1.0
-%{!?_release: %define _release 2}
+%{!?_release: %define _release 3}
 Release: %{_release}%{?dist}
 Summary: Mellanox BlueField boot partition management utility
 


### PR DESCRIPTION
This commit replaces the crc32x assembly instruction to be more
generic C code, so it can be compiled with compilers which doesn't
understand this intruction.

Signed-off-by: Liming Sun <lsun@mellanox.com>