### PR TITLE
Fix compiling error when building from different directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SBINDIR = /sbin
 # Default target.
 all:
 
-include package.mk
+include $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))/package.mk
 
 # By default, use the Makefile's directory as the vpath.
 VPATH := $(dir $(lastword $(MAKEFILE_LIST)))


### PR DESCRIPTION
THis commit fixes an error when building from different directory
using the "make -f xxx/Makefile" command.