### PR TITLE
Fix the sysfs path

### DIFF
--- a/mlxbf-bootctl.c
+++ b/mlxbf-bootctl.c
@@ -137,7 +137,7 @@ ssize_t read_or_die(const char* filename, int fd, void* buf, size_t count);
 #define EMMC_MIN_BOOT_SIZE 0x20000
 #define EMMC_BLOCK_SIZE 512
 
-#define SYS_PATH1 "/sys/bus/platform/drivers/mlx-bootctl"
+#define SYS_PATH1 "/sys/bus/platform/devices/MLNXBF04:00/driver"
 #define SYS_PATH2 "/sys/bus/platform/devices/MLNXBF04:00"
 #define SECOND_RESET_ACTION_PATH "second_reset_action"
 #define POST_RESET_WDOG_PATH "post_reset_wdog"


### PR DESCRIPTION
The mlxbf-bootctl module could be named as mlxbf-bootctl or mlx-bootctl. The sysfs files could be created at driver level (old builds) or device level (upstream kernel). In order to be backward-compatible, this commit updates the sysfs path to use MLNXBF04:00 instead of the driver name. It'll search driver-level path first using SYS_PATH1, then dearch device-level using SYS_PATH2. In this way, it could cover all the above scenarios.