### PR TITLE
Fix ACPI table read

### DIFF
--- a/mlxbf-bootctl.c
+++ b/mlxbf-bootctl.c
@@ -1075,8 +1075,8 @@ static void get_psc_app_filter_info(void)
     if (!buf)
       die("fail to alloc buf: %m");
     buf[st.st_size] = 0;
-    if (read(fd, buf, st.st_size) != st.st_size)
-      die("%s: read %m", path);
+    if (read_or_die(path, fd, buf, st.st_size) != st.st_size)
+      die("%s: unexpected read", path);
 
     close(fd);
 


### PR DESCRIPTION
mlxbf-bootctl reads ACPI SSDT table from sysfs which can only fetch up to 4KB in a single read. Recently the size of SSDT was increased over 4KB and exposes a bug in the read logic. The fix is to use read_or_die() which can handle continuous read and error conditions.

RM #3739450