### PR TITLE
Skip PSC cert patch DB if no need to update

### DIFF
--- a/mlxbf-bootctl.c
+++ b/mlxbf-bootctl.c
@@ -889,6 +889,9 @@ bool should_install_image(boot_image_header_t *hdr, int version, uint8_t *max_ve
   if (max_versions == NULL)
     die("internal: max_versions is NULL");
 
+  if ((hdr->image_id == PSC_APP_IMG_ID) && !psc_cert_update)
+    return false;
+
   // The logic to decide what to install and what not to install
   // is based on BlueField 1, 2, 3, <X> chips each possibly having
   // their own version of a specific image while at the same time


### PR DESCRIPTION
PSC cert patch DB was used to patch some signatures in the generated certificates for some boards. The 'psc_cert_update' flag will indicate whether the patch is needed or not. Previously this patch image is always written even with length zero, which causes a no-harm message "image 39 timeout" printed in rshim log and console. This fix checks the 'psc_cert_update' flag and skip the image if it's not set.

RM #3822976