### PR TITLE
Add build dependency for the install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ mlxbf-bootctl: $(SOURCES:.c=.o)
 
 all: mlxbf-bootctl
 
-install::
+install: mlxbf-bootctl
 	mkdir -p $(DESTDIR)$(SBINDIR)
 	cp -f mlxbf-bootctl $(DESTDIR)$(SBINDIR)
 


### PR DESCRIPTION
This commit adds the build dependency for the 'install' target to solve the issue seen in nightly build.